### PR TITLE
feat: add cla check

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,39 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.A1Y_BOT_TOKEN }}
+        with:
+          path-to-document: 'https://github.com/a1y-developer/.github/blob/main/CLA.md' # e.g. a CLA or a DCO document
+
+          # branch should not be protected
+          lock-pullrequest-aftermerge: True
+          path-to-signatures: 'signatures/version1/cla.json'
+          remote-organization-name: A1Y Developer
+          remote-repository-name: cla.db
+          branch: 'main'
+          allowlist: bot*
+
+          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the Contributor License Agreement (CLA) signing process using the CLA Assistant. The workflow is triggered by issue comments and pull request events.

### New GitHub Actions Workflow for CLA Signing

* [`.github/workflows/cla.yaml`](diffhunk://#diff-1b58984b53ae001ab8c245e8bd43f19a1e3865722079edceba65f613e600c747R1-R39): Added a new workflow named "CLA Assistant" that automates the CLA signing process. It triggers on issue comments and pull request events, and uses the `contributor-assistant/github-action@v2.3.0` action to manage CLA signatures.